### PR TITLE
fix(ui): actualizar navegación del monitor de costos a useRouter

### DIFF
--- a/src/app/admin/cost-monitor/page.tsx
+++ b/src/app/admin/cost-monitor/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
 import {
     TrendingUp, TrendingDown, DollarSign, BarChart3, Filter,
     Loader2, RefreshCw, ArrowUpRight, ArrowDownRight, Equal,
@@ -34,6 +35,7 @@ const formatDate = (dateStr: string) =>
     });
 
 export default function CostMonitorPage() {
+    const router = useRouter();
     const [period, setPeriod] = useState('30d');
     const [isLoading, setIsLoading] = useState(true);
     const [summary, setSummary] = useState<PriceDashboardSummary | null>(null);
@@ -75,7 +77,7 @@ export default function CostMonitorPage() {
             <nav className="sticky top-0 z-40 bg-white/90 backdrop-blur-lg border-b border-slate-200/60 shadow-sm">
                 <div className="max-w-7xl mx-auto px-4 md:px-6 py-3 flex items-center gap-3">
                     <button
-                        onClick={() => window.history.length > 1 ? window.history.back() : (window.location.href = '/dashboard')}
+                        onClick={() => window.history.length > 1 ? router.back() : router.push('/dashboard')}
                         className="flex items-center gap-2 px-3 py-2 text-sm font-bold text-slate-600 hover:text-slate-900 hover:bg-slate-100 rounded-xl transition-colors"
                     >
                         <ArrowLeft size={18} />


### PR DESCRIPTION
* Verificación de `WMSPage`: Se confirmó que los modales (p.ej. `MovementDetailModal`, `PurchaseOrderReceivingModal`) usan `z-50` o superior, por lo que los valores `z-30` y `z-20` para Header/Tabs no conflictúan.
* Verificación de `SupplyChainPage`: Se comprobó en código y pruebas que la fila del botón *Analizar* en móvil funciona correctamente usando `flex-shrink-0` junto a un wrap de los badges de stats, evitando así el desbordamiento.
* Corrección en `CostMonitorPage`: Se ha cambiado el código del botón de "Volver al sistema" para utilizar Next.js `useRouter`, evitando romper el comportamiento SPA mediante `window.location.href = '/dashboard'`.

---
*PR created automatically by Jules for task [12879657322170748872](https://jules.google.com/task/12879657322170748872) started by @filimorniga-ux*